### PR TITLE
Fix model links produced by ginsim.load(url) in notebooks

### DIFF
--- a/colomoto_jupyter/io.py
+++ b/colomoto_jupyter/io.py
@@ -10,7 +10,7 @@ import cellcollective
 
 def download(url, suffix=None):
     filename = new_output_file(suffix=suffix)
-    info("Downloading '%s'" % url)
+    info("Downloading %s" % url)
     filename, _ = urlretrieve(url, filename=filename)
     return filename
 


### PR DESCRIPTION
When loading a model from the url using ginsim.load(url) in notebook, a short text is outputted saying "Downloading 'url'".
This text is passed through a markdown processor to produce an actual link for the url. 

The problem is that this markdown processor doesn't seem to handle single quotes well, and the produce link is "url'", with a single quote at the end of the link, basically breaking the link. You can try it with the following code :

`from IPython.display import Markdown`
`text = "Downloading 'http://www.colomoto.org'"`
`Markdown(text)`

The simple fix here just removes the single quotes around the url.