### PR TITLE
Allowing maboss_setup to be called from a notebook

### DIFF
--- a/colomoto/setup_helper.py
+++ b/colomoto/setup_helper.py
@@ -12,6 +12,7 @@ except:
     # Python 2
     from urllib import urlretrieve
     from urllib2 import urlopen
+from colomoto_jupyter import IN_IPYTHON
 
 ##
 # Setup PATH env for custom colomoto installations
@@ -94,11 +95,18 @@ def setup(*specs):
     if os.path.exists(os.path.join(sys.prefix, 'conda-meta')):
         print("You seem to be within a conda environment, nothing to do.")
         return
-    from argparse import ArgumentParser
-    parser = ArgumentParser()
-    parser.add_argument("-f", "--force", default=False, action="store_true",
-            help="Force installation")
-    args = parser.parse_args()
+
+    from argparse import ArgumentParser, Namespace
+
+    if IN_IPYTHON:
+        args = Namespace()
+        args.force = False
+    else:
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--force", default=False, action="store_true",
+                help="Force installation")
+        args = parser.parse_args()
+
     prefix = installation_prefix()
     for spec in specs:
         name = spec["pkg"].split('/')[-1]


### PR DESCRIPTION
Hi, 

Today I discovered something which could be useful to work on shared python notebooks : Google Colaboratory. Here is an example : 
https://colab.research.google.com/drive/1_oW_sOHzi-ycbD77D2-_Nan9zmXuOur0

The problem I had was to install MaBoSS executables, using maboss_setup.py
When called from a notebook (via "import maboss_setup"), it would return an exception because the sys.argv are not what we were expecting. 
So I made a special case for notebooks (detected with sys.argv[0].endswith("ipykernel_launcher.py"), not sure if it's the best way), where it wouldn't look for the "force" argument, and default it to False.

Please let me know what you think !

